### PR TITLE
解决ng-cli 6 build失败

### DIFF
--- a/lib/libbase64.js
+++ b/lib/libbase64.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stream = require('stream');
+const stream = require('readable-stream');
 const Transform = stream.Transform;
 
 /**


### PR DESCRIPTION
解决
ERROR in 
Module not found: Error: Can't resolve 'stream' in ./node_modules/libbase64/lib/libbase64.js